### PR TITLE
Fix jQuery was undefined when trying to include it at the bottom of page

### DIFF
--- a/templates/modular/lightslider.html.twig
+++ b/templates/modular/lightslider.html.twig
@@ -11,34 +11,37 @@
 {% set settings = config.get('plugins.lightslider')|merge(settings) %}
 {% set unique_id = 'ls-' ~ random_string(10) %}
 
+{% do assets.addInlineJs('
+jQuery(document).ready(function($) {
+  $("#"+window.lightsliderId).lightSlider(window.lightsliderConfig);
+});
+', 120) %}
 <script type="text/javascript">
-  $(document).ready(function() {
-    $("#{{ unique_id }}").lightSlider({
-        item: {{ settings.item|default(1) }},
-        slideMove: {{ settings.slideMove|default(3) }},
-        slideMargin: {{ settings.slideMargin|default(5) }},
-        mode: '{{ settings.mode|default('slide') }}',
-        cssEasing: '{{ settings.cssEasing|default('ease') }}',
-        easing: '{{ settings.easing|default('') }}',
-        speed: {{ settings.speed|default(1000) }},
-        auto: {{ settings.auto|default('false') }},
-        loop: {{ settings.loop|default('false') }},
-        pause: {{ settings.pause|default(2000) }},
-        pauseOnHover: {{ settings.pauseOnHover|default(false) }},
-        controls: {{ settings.controls|default('true') }},
-        keyPress: {{ settings.keyPress|default('true') }},
-        adaptiveHeight: {{ settings.adaptiveHeight|default('true') }},
-        vertical: {{ settings.vertical|default('false') }},
-        verticalHeight: {{ settings.verticalHeight|default(500) }},
-        pager: {{ settings.pager|default('true') }},
-        gallery: {{ settings.gallery|default('false') }},
-        galleryMargin: {{ settings.gallery_margin|default(5) }},
-        thumbMargin: {{ settings.gallery_thumb_margin|default(5) }},
-        enableTouch: {{ settings.enableTouch|default('true') }},
-        enableDrag: {{ settings.enableDrag|default('true') }},
-
-    });
-  });
+lightsliderId = "{{ unique_id }}";
+lightsliderConfig = {
+  mode: "{{ settings.mode|default('slide') }}",
+  cssEasing: "{{ settings.cssEasing|default('ease-out') }}",
+  easing: "{{ settings.easing|default('') }}",
+  item: {{ settings.item|default(1) }},
+  slideMove: {{ settings.slideMove|default(3) }},
+  slideMargin: {{ settings.slideMargin|default(5) }},
+  speed: {{ settings.speed|default(1000) }},
+  auto: {{ settings.auto|default('false') }},
+  loop: {{ settings.loop|default('false') }},
+  pause: {{ settings.pause|default(2000) }},
+  pauseOnHover: {{ settings.pauseOnHover|default(false) }},
+  controls: {{ settings.controls|default('true') }},
+  keyPress: {{ settings.keyPress|default('true') }},
+  adaptiveHeight: {{ settings.adaptiveHeight|default('true') }},
+  vertical: {{ settings.vertical|default('false') }},
+  verticalHeight: {{ settings.verticalHeight|default(600) }},
+  pager: {{ settings.pager|default('true') }},
+  gallery: {{ settings.gallery|default('false') }},
+  galleryMargin: {{ settings.gallery_margin|default(5) }},
+  thumbMargin: {{ settings.gallery_thumb_margin|default(5) }},
+  enableTouch: {{ settings.enableTouch|default('true') }},
+  enableDrag: {{ settings.enableDrag|default('true') }}
+};
 </script>
 
 


### PR DESCRIPTION
I've just tried to launch LightSlider when my jQuery lib included at the bottom of page. 
After having undefined variable JS error I was forced to rewrite some of your JavaScript.
You can say: "No problem man, you can use include in at the top for jQuery!!!" and will be absolutely right but I don't want by my personal reason...

Here is the fix for LightSlider plugin that allows it to work even if jQuery included before closed BODY tag. The point is to define id and config as global variables and call init function at the bottom of page, after jQuery and lightslider.js libs.

PS I know that the global vars is an evil, but for now I haven't time...

@TODO wrap in scope