### PR TITLE
Add an option for a unique_id setting

### DIFF
--- a/templates/modular/lightslider.html.twig
+++ b/templates/modular/lightslider.html.twig
@@ -9,7 +9,8 @@
 {%  endif %}
 
 {% set settings = config.get('plugins.lightslider')|merge(settings) %}
-{% set unique_id = 'ls-' ~ random_string(10) %}
+{% if settings.unique_id %}{% set unique_id = settings.unique_id %}{% else %}{% set unique_id = 'ls-' ~ random_string(10) %}{% endif %}
+}
 
 <script type="text/javascript">
   $(document).ready(function() {


### PR DESCRIPTION
An unchanging unique_id can sometimes be useful for custom styling and custom js calls.