### PR TITLE
Assign slider instance to globally scoped variable

### DIFF
--- a/templates/modular/lightslider.html.twig
+++ b/templates/modular/lightslider.html.twig
@@ -13,7 +13,11 @@
 
 <script type="text/javascript">
   $(document).ready(function() {
-    $("#{{ unique_id }}").lightSlider({
+    window.Grav = $.extend({}, window.Grav);
+    window.Grav.plugins = $.extend({}, window.Grav.plugins);
+    window.Grav.plugins.lightSlider = {};
+
+    window.Grav.plugins.lightSlider['{{ unique_id }}'] = $("#{{ unique_id }}").lightSlider({
         item: {{ settings.item|default(1) }},
         slideMove: {{ settings.slideMove|default(3) }},
         slideMargin: {{ settings.slideMargin|default(5) }},


### PR DESCRIPTION
Allows access to the full lightSlider API including public methods and its callback properties, and thus resolves #20. (should have put that in commit message :/)

I wasn't sure how best to make this globally available. As you'll see, I've created a nested property attached to a `Grav` property I invented, which is a property of the global `window` object. The hierarchical object structure `window.Grav.plugins...` is a suggestion, and may be a useful structure in other plugins.

I don't mind if this global variable is changed, as long as I can reference the slider instance from any user Javascript.