### PR TITLE
Add `alt` attribute to images.

### DIFF
--- a/templates/modular/lightslider.html.twig
+++ b/templates/modular/lightslider.html.twig
@@ -77,7 +77,7 @@
                 {% set image_data_thumb = 'data-thumb=\"'~image.cropResize(settings.gallery_thumb_width|default(100),settings.gallery_thumb_height|default(100)).url~'\"' %}
             {% endif %}
             <li {{ image_data_thumb }}>
-                <img src="{{ image.url }}" />
+                <img src="{{ image.url }}" alt="" />
             </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
When validating the HTML, here what one gets:

> Error: An “img” element must have an “alt” attribute, except under certain conditions. For details, consult guidance on providing text alternatives for images.

See [W3C website](https://www.w3.org/wiki/HTML/Usage/TextAlternatives) for more informations!